### PR TITLE
Making js and css relative

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -12,15 +12,15 @@
 <meta name="description" content="{{ .Site.Params.description }}">
 {{- end }}
 {{ .Hugo.Generator }}
-<link href="{{ .Site.BaseURL }}index.xml" rel="alternate" type="application/rss+xml">
+<link href="/index.xml" rel="alternate" type="application/rss+xml">
 <link rel="canonical" href="{{ .Permalink }}">
-<link rel="stylesheet" href="{{"css/theme.min.css" | absURL}}">
+<link rel="stylesheet" href="/css/theme.min.css">
 <script src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
 {{ partial "meta/chroma.html" . -}}
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js"></script>
-<script src="{{"js/functions.min.js" | absURL}}"></script>
+<script src="/js/functions.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jquery.easing@1.4.1/jquery.easing.min.js"></script>
-<script src="{{"js/jquery.backtothetop/jquery.backtothetop.min.js" | absURL}}"></script>
+<script src="/js/jquery.backtothetop/jquery.backtothetop.min.js"></script>
 {{- partial "meta/google-analytics-async.html" . -}}
 {{- partial "meta/tag-manager.html" . -}}
 {{- partial "meta/google-site-verification.html" . -}}


### PR DESCRIPTION
This is helpful when testing the public site locally (i.e. not with `hugo server`) or viewing it on [Netlify Deploy Previews](https://www.netlify.com/blog/2016/07/20/introducing-deploy-previews-in-netlify/). In both of those cases, the base URL is different than what is in the `config.toml` file, so all the links to CSS and JS assets would 404. This patch makes some of them into relative links, so they don't 404 in these cases