### PR TITLE
Menu: use LinkTitle instead of Title

### DIFF
--- a/layouts/partials/menu/open-menu.html
+++ b/layouts/partials/menu/open-menu.html
@@ -22,7 +22,7 @@
 {{- else -}}
   {{- safeHTML .Params.head -}}
   {{- $numberOfPages := (add (len .Pages) (len .Sections)) -}}
-<li class="{{ if .IsAncestor $currentNode }}parent{{ end }}{{ if and .File $currentNode.File }}{{ if eq .File.UniqueID $currentNode.File.UniqueID }} active{{ end }}{{ end }}{{ if .Params.alwaysopen }} parent{{ end }}"><a href="{{ .Permalink }}">{{ safeHTML .Params.Pre }}{{ .Title }}{{ safeHTML .Params.Post }}</a>
+<li class="{{ if .IsAncestor $currentNode }}parent{{ end }}{{ if and .File $currentNode.File }}{{ if eq .File.UniqueID $currentNode.File.UniqueID }} active{{ end }}{{ end }}{{ if .Params.alwaysopen }} parent{{ end }}"><a href="{{ .Permalink }}">{{ safeHTML .Params.Pre }}{{ .LinkTitle }}{{ safeHTML .Params.Post }}</a>
   {{ if ne $numberOfPages 0 }}
 <ul class="sub-menu">
     {{- .Scratch.Set "pages" .Pages -}}
@@ -51,7 +51,7 @@
 {{- end -}}
 {{- else -}}
   {{- if not .Params.Hidden -}}
-<li class="{{ if and .File $currentNode.File }}{{ if eq .File.UniqueID $currentNode.File.UniqueID }}active{{ end }}{{ end }}"><a href="{{ .Permalink }}">{{ safeHTML .Params.Pre }}{{ .Title }}{{ safeHTML .Params.Post }}</a></li>
+<li class="{{ if and .File $currentNode.File }}{{ if eq .File.UniqueID $currentNode.File.UniqueID }}active{{ end }}{{ end }}"><a href="{{ .Permalink }}">{{ safeHTML .Params.Pre }}{{ .LinkTitle }}{{ safeHTML .Params.Post }}</a></li>
   {{- end -}}
 {{ end -}}
 {{ end -}}

--- a/layouts/partials/menu/slide-menu.html
+++ b/layouts/partials/menu/slide-menu.html
@@ -22,7 +22,7 @@
 {{- else -}}
   {{- safeHTML .Params.head -}}
   {{- $numberOfPages := (add (len .Pages) (len .Sections)) -}}
-<li class="{{ if .IsAncestor $currentNode }}parent{{ end }}{{ if and .File $currentNode.File }}{{ if eq .File.UniqueID $currentNode.File.UniqueID }} active{{ end }}{{ end }}{{ if ne $numberOfPages 0 }} has-sub-menu{{ end }}"><a href="{{ .Permalink }}">{{ safeHTML .Params.Pre }}{{ .Title }}{{ safeHTML .Params.Post }}{{ if ne $numberOfPages 0 }}{{ if .IsAncestor $currentNode }}<span class="mark opened">-</span>{{ else }}<span class="mark closed">+</span>{{ end }}{{ end }}</a>
+<li class="{{ if .IsAncestor $currentNode }}parent{{ end }}{{ if and .File $currentNode.File }}{{ if eq .File.UniqueID $currentNode.File.UniqueID }} active{{ end }}{{ end }}{{ if ne $numberOfPages 0 }} has-sub-menu{{ end }}"><a href="{{ .Permalink }}">{{ safeHTML .Params.Pre }}{{ .LinkTitle }}{{ safeHTML .Params.Post }}{{ if ne $numberOfPages 0 }}{{ if .IsAncestor $currentNode }}<span class="mark opened">-</span>{{ else }}<span class="mark closed">+</span>{{ end }}{{ end }}</a>
   {{ if ne $numberOfPages 0 }}
 <ul class="sub-menu">
     {{- .Scratch.Set "pages" .Pages -}}
@@ -51,7 +51,7 @@
 {{- end -}}
 {{- else -}}
   {{- if not .Params.Hidden -}}
-<li class="{{ if and .File $currentNode.File }}{{ if eq .File.UniqueID $currentNode.File.UniqueID }}active{{ end }}{{ end }}"><a href="{{ .Permalink }}">{{ safeHTML .Params.Pre }}{{ .Title }}{{ safeHTML .Params.Post }}</a></li>
+<li class="{{ if and .File $currentNode.File }}{{ if eq .File.UniqueID $currentNode.File.UniqueID }}active{{ end }}{{ end }}"><a href="{{ .Permalink }}">{{ safeHTML .Params.Pre }}{{ .LinkTitle }}{{ safeHTML .Params.Post }}</a></li>
   {{- end -}}
 {{ end -}}
 {{ end -}}


### PR DESCRIPTION
LinkTitle allows overriding the title to use in menus in a page's front-matter. For example:

```yaml
title: This is the title of the page
linktitle: menu title
```

It a linktitle is defined in the page's front-matter, it will be used as title in the menu. Pages that do not have a linktitle configured will use the `title` instead (see https://gohugo.io/content-management/front-matter/).
