### PR TITLE
pre and post elements added to menu items

### DIFF
--- a/layouts/partials/global-menu.html
+++ b/layouts/partials/global-menu.html
@@ -5,18 +5,32 @@
 <ul>
 {{- range .Site.Menus.main.ByWeight -}}
 {{ if .HasChildren -}}
-<li class="parent{{ if $currentPage.HasMenuCurrent "main" . }} active{{ end }}"><a href="{{ .URL }}">{{- .Name -}} <i class="fas fa-angle-right"></i></a>
+<li class="parent{{ if $currentPage.HasMenuCurrent "main" . }} active{{ end }}">{{template "menu-item" dict "item" .}}
 <ul class="sub-menu">
 {{ range .Children -}}
-<li class="child{{ if $currentPage.HasMenuCurrent "main" . }} active{{ end }}"><a href="{{ .URL }}">{{ .Name }}</a></li>
+<li class="child{{ if $currentPage.HasMenuCurrent "main" . }} active{{ end }}">{{template "menu-item" dict "item" .}}</li>
 {{ end -}}
 </ul>
 </li>
 {{- else }}
-<li{{ if $currentPage.HasMenuCurrent "main" . }} class="active"{{ end }}><a href="{{ .URL }}">{{- .Name -}}</a></li>
+<li{{ if $currentPage.HasMenuCurrent "main" . }} class="active"{{ end }}>{{template "menu-item" dict "item" .}}</li>
 {{- end -}}
 {{- end -}}
 </ul>
 </nav>
 </div>
 {{- end }}
+
+{{define "menu-item"}}
+{{- with .item -}}
+<a href="{{ .URL }}">
+  {{- with .Pre -}}{{- . -}}{{- end -}}
+  {{- .Name -}}
+  {{- with .Post -}}{{- . -}}{{- end -}}
+  {{ if .HasChildren -}}
+  <i class="fas fa-angle-right"></i>
+  {{ end -}}  
+</a>
+{{- end -}}
+{{- end -}}
+


### PR DESCRIPTION
This change allows adding the `pre` and `post` raw HTML elements (good for icons, emojis, etc.) to the menu items as described in https://gohugo.io/content-management/menus/#add-non-content-entries-to-a-menu :)

To test it, you can add this to the `demo_config.toml`:
```diff
     [[menu.main]]
         name = "Twitter"
+        pre = "<b>pre!</b>"
+        post = "<b>post!</b>"
         url = "https://twitter.com/thingsym"
         weight = 2
 
+    [[menu.main]]
+        name = "sub"
+        pre = "<b>pre!</b>"
+        post = "<b>post!</b>"
+        url = "https://twitter.com/thingsym"
+        weight = 2
+        parent = "Twitter"
+
```