### PR TITLE
fix fontawesome load logic

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,7 +16,7 @@
 <link rel="canonical" href="{{ .Permalink }}">
 <link rel="stylesheet" href="{{"css/theme.min.css" | absURL}}">
 {{ partial "meta/chroma.html" . -}}
-<script defer src="{{ .Site.BaseURL }}/js/fontawesome6/all.min.js"></script>
+<script defer src="{{ "js/fontawesome6/all.min.js" | absURL }}"></script>
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/jquery.easing@1.4.1/jquery.easing.min.js" integrity="sha256-H3cjtrm/ztDeuhCN9I4yh4iN2Ybx/y1RM7rMmAesA0k=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.11/dist/clipboard.min.js" integrity="sha256-4XodgW4TwIJuDtf+v6vDJ39FVxI0veC/kSCCmnFp7ck=" crossorigin="anonymous"></script>


### PR DESCRIPTION
just as the "bundle.js" or "theme.min.css" are being done.
Otherwise fontawesome doesn't work when "baseURL" is set to "/" in config, especially for my site.

(I use different domain name for mirrors so I can't use baseURL configuration of Hugo)