### PR TITLE
Fix deprecation warning

### DIFF
--- a/layouts/partials/meta/google-analytics-async.html
+++ b/layouts/partials/meta/google-analytics-async.html
@@ -1,4 +1,4 @@
-{{- if .Site.IsServer -}}
+{{- if hugo.IsServer -}}
 <!-- only production, not generate Google Analytics with Hugo’s built-in server -->
 {{- else -}}
 {{- with .Site.Params.google_analytics_id -}}

--- a/layouts/partials/meta/google-site-verification.html
+++ b/layouts/partials/meta/google-site-verification.html
@@ -1,4 +1,4 @@
-{{- if .Site.IsServer -}}
+{{- if hugo.IsServer -}}
 <!-- only production, not generate google-site-verification with Hugo’s built-in server -->
 {{- else -}}
 {{- if .IsHome -}}

--- a/layouts/partials/meta/tag-manager.html
+++ b/layouts/partials/meta/tag-manager.html
@@ -1,4 +1,4 @@
-{{- if .Site.IsServer -}}
+{{- if hugo.IsServer -}}
 <!-- only production, not generate Tag Manager with Hugo’s built-in server -->
 {{- else -}}
 {{- with .Site.Params.tag_manager_container_id -}}

--- a/layouts/partials/prepend-body.html
+++ b/layouts/partials/prepend-body.html
@@ -1,4 +1,4 @@
-{{ if .Site.IsServer }}
+{{ if hugo.IsServer }}
 <!-- only production, not generate Google Analytics with Hugo’s built-in server -->
 {{ else }}
 {{- with .Site.Params.tag_manager_container_id -}}


### PR DESCRIPTION
When previewing example site with hugo 0.124.1, a deprecation warning is shown:

```
INFO  deprecated: .Site.IsServer was deprecated in Hugo v0.120.0 and will be removed in a future release. Use hugo.IsServer instead.
```

This PR fixes that issue.